### PR TITLE
ALF001-VeryLowMinSci

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -67,3 +67,5 @@ ChangeLog
 		Fixed value of next run of experiment being calculated incorrectly when runs of experiment already done but not yet recovered at KSC.
 		Set VeryLowMinScience to range from 0.0001 to 0.1
 		Fixed experiments not being re-classified as completed or incomplete (and hidden or shown) after a change in the MinScience threshold changes their "status".
+		Fixed 'Here and Now' window not resizing correctly when hiding MinScience slider.
+		Fixed position of experiment buttons in 'Here and Now' window when MinScience slider hidden.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -70,3 +70,4 @@ ChangeLog
 		Fixed 'Here and Now' window not resizing correctly when hiding MinScience slider.
 		Fixed position of experiment buttons in 'Here and Now' window when MinScience slider hidden.
 		Fixed experiments not being re-classified as incomplete (or completed) when switching between regular and VeryLowMinScience if MinScience slider hidden.
+		Fixed text spanning outside of buttons and/or progress bars in some cases.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -72,3 +72,4 @@ ChangeLog
 		Fixed experiments not being re-classified as incomplete (or completed) when switching between regular and VeryLowMinScience if MinScience slider hidden.
 		Fixed text spanning outside of buttons and/or progress bars in some cases.
 		Added the Recoverd+OnBoard science value to be shown below experiment description on experiment buttons in the 'Here and Now' window, and tooltip describing button contents.
+		Experiment values now shown with up to two decimal digits in progress bars.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -66,3 +66,4 @@ ChangeLog
 	Fixes / evolutions by Github user @alartor
 		Fixed value of next run of experiment being calculated incorrectly when runs of experiment already done but not yet recovered at KSC.
 		Set VeryLowMinScience to range from 0.0001 to 0.1
+		Fixed experiments not being re-classified as completed or incomplete (and hidden or shown) after a change in the MinScience threshold changes their "status".

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -71,3 +71,4 @@ ChangeLog
 		Fixed position of experiment buttons in 'Here and Now' window when MinScience slider hidden.
 		Fixed experiments not being re-classified as incomplete (or completed) when switching between regular and VeryLowMinScience if MinScience slider hidden.
 		Fixed text spanning outside of buttons and/or progress bars in some cases.
+		Added the Recoverd+OnBoard science value to be shown below experiment description on experiment buttons in the 'Here and Now' window, and tooltip describing button contents.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -69,3 +69,4 @@ ChangeLog
 		Fixed experiments not being re-classified as completed or incomplete (and hidden or shown) after a change in the MinScience threshold changes their "status".
 		Fixed 'Here and Now' window not resizing correctly when hiding MinScience slider.
 		Fixed position of experiment buttons in 'Here and Now' window when MinScience slider hidden.
+		Fixed experiments not being re-classified as incomplete (or completed) when switching between regular and VeryLowMinScience if MinScience slider hidden.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -65,3 +65,4 @@ ChangeLog
 6.0.1.1
 	Fixes / evolutions by Github user @alartor
 		Fixed value of next run of experiment being calculated incorrectly when runs of experiment already done but not yet recovered at KSC.
+		Set VeryLowMinScience to range from 0.0001 to 0.1

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -61,3 +61,7 @@ ChangeLog
 6.0.1
 	Fixed all areas where 0.1 was hardcoded in place for the minimum  science
 	Added option to totally hide the Min Science Slider on the Here & Now window
+
+6.0.1.1
+	Fixes / evolutions by Github user @alartor
+		Fixed value of next run of experiment being calculated incorrectly when runs of experiment already done but not yet recovered at KSC.

--- a/TODO.txt
+++ b/TODO.txt
@@ -52,6 +52,11 @@ experimentValue /= Mathf.Pow( (1-(.baseValue/.scienceCap))f , subjectOnboardData
 			}
 where calculating again "next" would give the correct value for "experimentValue" variable above. Also of note is that around this last lines of code, the 0.1 value for min science is again hard-coded...
 
+====>	[alartor]: FIXED
+====>	Fixed the expermientValue formula so that the values are calculated correctly.
+
+
+
 3.- Finally, I'm wondering if line 408 in StatusWindow.cs could be changed so that in the main window a two decimal digits precision be shown, from:
 
                 GUI.Label(labelRect, string.Format("{0:0.#}  /  {1:0.#}", curr, total), _progressLabelStyle);

--- a/TODO.txt
+++ b/TODO.txt
@@ -81,3 +81,5 @@ OTHER CHANGES:
 
 ====>	[alartor]
 ====>	Fixed "Here and Now" and Main window (both normal and compact) not showing (or hiding) experiments after a change in the MinScience threshold implies experiment is now incomplete (or completed).
+====>	Fixed "Here and Now" window size not updating correctly when hiding MinScience slider.
+====>	Fixed position of experiment buttons in "Here and Now" window when MinScience slider hidden.

--- a/TODO.txt
+++ b/TODO.txt
@@ -73,6 +73,9 @@ to
 
                 GUI.Label(labelRect, string.Format("{0:0.##}  /  {1:0.##}", curr, total), _progressLabelStyle);
 
+====>	[alartor]: FIXED
+====>	Tweaked format so that value is shown with two decimal digits and still fits inside the progress bar, both in "Here and Now" and main windows.
+
 
 
 OTHER CHANGES:

--- a/TODO.txt
+++ b/TODO.txt
@@ -72,3 +72,12 @@ where calculating again "next" would give the correct value for "experimentValue
 to 
 
                 GUI.Label(labelRect, string.Format("{0:0.##}  /  {1:0.##}", curr, total), _progressLabelStyle);
+
+
+
+OTHER CHANGES:
+
+
+
+====>	[alartor]
+====>	Fixed "Here and Now" and Main window (both normal and compact) not showing (or hiding) experiments after a change in the MinScience threshold implies experiment is now incomplete (or completed).

--- a/TODO.txt
+++ b/TODO.txt
@@ -87,3 +87,7 @@ OTHER CHANGES:
 
 ====>	[alartor]
 ====>	Slightly tweaked font sizes in experiment buttons and progress bars, so that text fits correctly inside their alloted space.
+
+====>	[alartor]
+====>	Added the Recoverd+OnBoard science value to be shown below experiment description on experiment buttons in the "Here and Now" window.
+====>	Added tooltip describing the text shown on the experiment buttons in the "Here and Now" window.

--- a/TODO.txt
+++ b/TODO.txt
@@ -83,3 +83,4 @@ OTHER CHANGES:
 ====>	Fixed "Here and Now" and Main window (both normal and compact) not showing (or hiding) experiments after a change in the MinScience threshold implies experiment is now incomplete (or completed).
 ====>	Fixed "Here and Now" window size not updating correctly when hiding MinScience slider.
 ====>	Fixed position of experiment buttons in "Here and Now" window when MinScience slider hidden.
+====>	Fixed experiments not being re-classified as incomplete (or completed) when switching between regular and VeryLowMinScience if MinScience slider hidden.

--- a/TODO.txt
+++ b/TODO.txt
@@ -84,3 +84,6 @@ OTHER CHANGES:
 ====>	Fixed "Here and Now" window size not updating correctly when hiding MinScience slider.
 ====>	Fixed position of experiment buttons in "Here and Now" window when MinScience slider hidden.
 ====>	Fixed experiments not being re-classified as incomplete (or completed) when switching between regular and VeryLowMinScience if MinScience slider hidden.
+
+====>	[alartor]
+====>	Slightly tweaked font sizes in experiment buttons and progress bars, so that text fits correctly inside their alloted space.

--- a/TODO.txt
+++ b/TODO.txt
@@ -11,6 +11,15 @@ if I understand correctly, maybe the following lines could be added after the op
 
                 new Adds.StepRule(0.001f, 0.01f),
                 new Adds.StepRule(0.01f, 0.1f),
+
+====>	[alartor]: FIXED
+====>	Modified so that "VeryLowMinScience" actually sets the slider to go from 0.0001 to 0.1
+====>	Updated tooltip text for the "VeryLowMinScience" option in the settings window accordingly.
+====>	Updated StepRules accordingly and the "pow" parameter so that the "AcceleratedSlider" goes through reasonable steps.
+====>	Modified format so that only significant decimal digits (i.e. not rightmost zeros) are shown.
+
+
+
 2.- Regarding the inaccurate amount reported in the "Hear and Now" window (see this quote from my previous post):
 
   On 7/4/2022 at 5:08 PM, alartor said:

--- a/X-Science.version
+++ b/X-Science.version
@@ -7,7 +7,7 @@
     "MAJOR": 6,
     "MINOR": 0,
     "PATCH": 1,
-    "BUILD": 0
+    "BUILD": 1
   },
   "KSP_VERSION": {
     "MAJOR": 1,

--- a/X-Science/AssemblyVersion.cs
+++ b/X-Science/AssemblyVersion.cs
@@ -5,5 +5,5 @@
   
  using System.Reflection;
 
- [assembly: AssemblyVersion("6.0.0.10")]
- [assembly: AssemblyFileVersion("6.0.0.10")]
+ [assembly: AssemblyVersion("6.0.1.1")]
+ [assembly: AssemblyFileVersion("6.0.1.1")]

--- a/X-Science/ExperimentFilter.cs
+++ b/X-Science/ExperimentFilter.cs
@@ -218,7 +218,7 @@ namespace ScienceChecklist {
 
                 if (subjectOnboardData.Length > 1)
                 {
-                    experimentValue /= Mathf.Pow(4f, subjectOnboardData.Length - 1);
+                    experimentValue *= Mathf.Pow(1-(exp.ScienceExperiment.baseValue/exp.ScienceExperiment.scienceCap), subjectOnboardData.Length - 1);
                 }
             }
 

--- a/X-Science/ScienceWindow.cs
+++ b/X-Science/ScienceWindow.cs
@@ -671,7 +671,7 @@ namespace ScienceChecklist
 			var progressRect = new Rect(rect)
 			{
 				xMin = rect.xMax - (compact ? wScale(75) : wScale(105)),
-				xMax = rect.xMax - (compact ? wScale(40) : wScale(40)),
+				xMax = rect.xMax - (compact ? wScale(40) : wScale(35)),
 				y = rect.y + (compact ? wScale(1) : wScale(3)),
 			};
 			GUI.Label(labelRect, exp.Description, labelStyle);
@@ -728,11 +728,11 @@ namespace ScienceChecklist
 
 			if (showValues)
 			{
-			var labelRect = new Rect(rect)
-			{
-				y = rect.y - wScale(1),
+				var labelRect = new Rect(rect)
+				{
+					y = rect.y - wScale(1),
 				};
-				GUI.Label(labelRect, string.Format("{0:0.#}  /  {1:0.#}", curr, total), _progressLabelStyle);
+				GUI.Label(labelRect, string.Format("{0:0.##}  /  {1:0.##}", curr, total), _progressLabelStyle);
 			}
 		}
 

--- a/X-Science/ScienceWindow.cs
+++ b/X-Science/ScienceWindow.cs
@@ -48,6 +48,7 @@ namespace ScienceChecklist
 
 		private string _lastTooltip;
 		private bool _compactMode;
+		private float _previousSciThreshold;
 
 		private readonly Texture2D _progressTexture;
 		private readonly Texture2D _completeTexture;
@@ -410,6 +411,13 @@ namespace ScienceChecklist
 
 			GUILayout.BeginVertical(GUILayout.Width(wScale(480)), GUILayout.ExpandHeight(true));
 
+			if (ScienceChecklistAddon.Config.ScienceThreshold != _previousSciThreshold)
+			{
+				_parent.Science.UpdateAllScienceInstances();
+				_filter.UpdateFilter();
+				_previousSciThreshold = ScienceChecklistAddon.Config.ScienceThreshold;
+			}
+
 			ProgressBar(
 				wScale(new Rect(10, 27, 480, 13)),
 				_filter.TotalCount == 0 ? 1 : _filter.CompleteCount,
@@ -552,6 +560,13 @@ namespace ScienceChecklist
 			GUILayout.BeginHorizontal( );
 			GUILayout.Label("", GUILayout.Height(wScale(20)));
 			GUILayout.EndHorizontal( );
+
+			if (ScienceChecklistAddon.Config.ScienceThreshold != _previousSciThreshold)
+			{
+				_parent.Science.UpdateAllScienceInstances();
+				_filter.UpdateFilter();
+				_previousSciThreshold = ScienceChecklistAddon.Config.ScienceThreshold;
+			}
 
 			GUILayout.BeginVertical();
 			_compactScrollPos = GUILayout.BeginScrollView(_compactScrollPos);

--- a/X-Science/SettingsWindow.cs
+++ b/X-Science/SettingsWindow.cs
@@ -96,7 +96,7 @@ namespace ScienceChecklist
 			}
 
 
-			toggle = GUILayout.Toggle(ScienceChecklistAddon.Config.VeryLowMinScience, new GUIContent("Low Min Science", "Minimum science slider in the Here & Now window will go to 0.001"), toggleStyle);
+			toggle = GUILayout.Toggle(ScienceChecklistAddon.Config.VeryLowMinScience, new GUIContent("Low Min Science", "Minimum science slider in the Here & Now window will go fom 0.0001 to 0.1"), toggleStyle);
 			if (toggle != ScienceChecklistAddon.Config.VeryLowMinScience)
 			{
 				ScienceChecklistAddon.Config.VeryLowMinScience = toggle;

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -28,6 +28,7 @@ namespace ScienceChecklist
         private readonly Logger _logger;
         private int _previousNumExperiments;
         private float _previousUiScale;
+        private bool _previousHideMinSciSlider;
         private GUIStyle _experimentButtonStyle;
         private GUIStyle _experimentLabelStyle;
         private GUIStyle _situationStyle;
@@ -226,7 +227,7 @@ namespace ScienceChecklist
                 }
             }
 
-            int Top = wScale(90 - (ScienceChecklistAddon.Config.HideMinScienceSlider?10:0));
+            int Top = wScale(90 - (ScienceChecklistAddon.Config.HideMinScienceSlider ? 25 : 0));
             if (_filter.DisplayScienceInstances != null)
             {
                 for (var i = 0; i < _filter.DisplayScienceInstances.Count; i++)
@@ -238,16 +239,12 @@ namespace ScienceChecklist
                         var rect = new Rect(wScale(5), Top, wScale(250), wScale(30));
                         DrawExperiment(experiment, rect);
                         Top += wScale(35);
+                        GUILayout.Space(wScale(35));
                     }
                 }
             }
             else
                 _logger.Trace("DisplayExperiments is null");
-
-
-
-            if (_filter.DisplayScienceInstances.Count > 0)
-                GUILayout.Space(wScale(_filter.DisplayScienceInstances.Count * 35)); // Leave space for experiments, as drawn above
 
             GUILayout.Space(wScale(10));
 
@@ -299,12 +296,16 @@ namespace ScienceChecklist
         {
             // The window needs to get smaller when the number of experiments drops.
             // This allows that while preventing flickering.
-            if (_previousNumExperiments != _filter.DisplayScienceInstances.Count || ScienceChecklistAddon.Config.UiScale != _previousUiScale)
+            if (   _previousNumExperiments != _filter.DisplayScienceInstances.Count
+                || ScienceChecklistAddon.Config.UiScale != _previousUiScale
+                || ScienceChecklistAddon.Config.HideMinScienceSlider != _previousHideMinSciSlider
+               )
             {
                 windowPos.height = wScale(30) + ((_filter.DisplayScienceInstances.Count + 1) * wScale(35));
                 windowPos.width = wScale(defaultWindowSize.x);
                 _previousNumExperiments = _filter.DisplayScienceInstances.Count;
                 _previousUiScale = ScienceChecklistAddon.Config.UiScale;
+                _previousHideMinSciSlider = ScienceChecklistAddon.Config.HideMinScienceSlider;
             }
 
             base.DrawWindow();

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -456,7 +456,7 @@ namespace ScienceChecklist
                 {
                     y = progressRect.y + 1,
                 };
-                GUI.Label(labelRect, string.Format("{0:0.#}  /  {1:0.#}", curr, total), _progressLabelStyle);
+                GUI.Label(labelRect, string.Format("{0:0.##}/{1:0.##}", curr, total), _progressLabelStyle);
             }
         }
 

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -199,6 +199,8 @@ namespace ScienceChecklist
                     {
                         ScienceChecklistAddon.Config.ScienceThreshold = scienceThreshold;
                         ScienceChecklistAddon.Config.Save();
+                        _parent.Science.UpdateAllScienceInstances();
+                        _filter.UpdateFilter();
                     }
 
                     string format = "F1";

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -88,7 +88,7 @@ namespace ScienceChecklist
             {
                 fontStyle = FontStyle.BoldAndItalic,
                 alignment = TextAnchor.MiddleCenter,
-                fontSize = wScale(11),
+                fontSize = wScale(9),
                 normal = {
                     textColor = new Color(0.322f, 0.298f, 0.004f)
                 }
@@ -119,11 +119,11 @@ namespace ScienceChecklist
             };
             _experimentButtonStyle = new GUIStyle(_skin.button)
             {
-                fontSize = wScale(14)
+                fontSize = wScale(12)
             };
             _experimentLabelStyle = new GUIStyle(_experimentButtonStyle)
             {
-                fontSize = wScale(14),
+                fontSize = wScale(12),
                 normal = { textColor = Color.black }
             };
         }

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -170,31 +170,54 @@ namespace ScienceChecklist
                 {
                     GUILayout.Label("Min Science", _scienceThresholdLabelStyle);
 
-                    float minSci = ScienceChecklistAddon.Config.VeryLowMinScience ? 0.001f : .1f;
-                    float prev_scienceThreshold = Math.Max(ScienceChecklistAddon.Config.ScienceThreshold, minSci);
-                    float scienceThreshold = Adds.AcceleratedSlider(prev_scienceThreshold, minSci, 50f, 1.8f, new[] {
+                    float scienceThreshold = 0f;
+                    if (ScienceChecklistAddon.Config.VeryLowMinScience)
+                    {
+                        float minSci = 0.0001f;
+                        float maxSci = 0.1f;
+                        float prev_scienceThreshold = Math.Min(Math.Max(ScienceChecklistAddon.Config.ScienceThreshold, minSci), maxSci);
+                        scienceThreshold = Adds.AcceleratedSlider(prev_scienceThreshold, minSci, maxSci, 2.7f, new[]
+                        {
+                            new Adds.StepRule(0.0001f, 0.005f),
+                            new Adds.StepRule(0.001f, 0.01f),
+                            new Adds.StepRule(0.01f, 0.1f),
+                        });
+                    }
+                    else
+                    {
+                        float minSci = 0.1f;
+                        float maxSci = 50f;
+                        float prev_scienceThreshold = Math.Min(Math.Max(ScienceChecklistAddon.Config.ScienceThreshold, minSci), maxSci);
+                        scienceThreshold = Adds.AcceleratedSlider(prev_scienceThreshold, minSci, maxSci, 1.8f, new[]
+                        {
                             new Adds.StepRule(0.5f, 10f),
                             new Adds.StepRule(1f, 40f),
                             new Adds.StepRule(2f, 50f),
                         });
-
+                    }
                     if (ScienceChecklistAddon.Config.ScienceThreshold != scienceThreshold)
                     {
                         ScienceChecklistAddon.Config.ScienceThreshold = scienceThreshold;
                         ScienceChecklistAddon.Config.Save();
                     }
 
-                    string format;
-                    int width;
-                    if (ScienceChecklistAddon.Config.VeryLowMinScience && (scienceThreshold < 1f))
+                    string format = "F1";
+                    int width = 26;
+                    if (ScienceChecklistAddon.Config.VeryLowMinScience)
                     {
-                        format = "F3";
+                        if (scienceThreshold < 0.005f)
+                        {
+                            format = "F4";
+                        }
+                        else if (scienceThreshold < 0.01f)
+                        {
+                            format = "F3";
+                        }
+                        else if (scienceThreshold < 0.1f)
+                        {
+                            format = "F2";
+                        }
                         width = 40;
-                    }
-                    else
-                    {
-                        format = "F1";
-                        width = 26;
                     }
                     GUILayout.Label(ScienceChecklistAddon.Config.ScienceThreshold.ToString(format), _scienceThresholdLabelStyle, GUILayout.Width(wScale(width)));
 

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -390,19 +390,22 @@ namespace ScienceChecklist
             bool ExperimentRunnable = CanRunExperiment(exp, true);
             Rect buttonRect = new Rect(rect) { xMax = wScale(200) };
             string scienceValueString = " (" + exp.NextScienceIncome.ToString(
-                ScienceChecklistAddon.Config.VeryLowMinScience && exp.NextScienceIncome < 1 ? "F3" : "F1") + ")";
+                ScienceChecklistAddon.Config.VeryLowMinScience && exp.NextScienceIncome < 1 ? "F3" : "F1"
+                ) + ")\n" + (exp.CompletedScience + exp.OnboardScience).ToString("F2");
+            GUIContent expContent = new GUIContent(exp.ShortDescription + scienceValueString,
+                "Experiment description (next run value)\n\nRecovered+OnBoard value");
 
             if (ExperimentRunnable)
             {
                 _experimentButtonStyle.normal.textColor = exp.IsComplete ? Color.green : Color.yellow;
-                if (GUI.Button(buttonRect, exp.ShortDescription + scienceValueString, _experimentButtonStyle))
+                if (GUI.Button(buttonRect, expContent, _experimentButtonStyle))
                 {
                     RunExperiment(exp);
                 }
             }
             else
             {
-                GUI.Label(buttonRect, exp.ShortDescription + scienceValueString, _experimentLabelStyle);
+                GUI.Label(buttonRect, expContent, _experimentLabelStyle);
             }
             int Dif = (int)(((rect.yMax - rect.yMin) - wScale(13)) / 2);
             Rect progressRect = new Rect(wScale(205), rect.yMin + Dif, wScale(50), wScale(13));

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -28,6 +28,7 @@ namespace ScienceChecklist
         private readonly Logger _logger;
         private int _previousNumExperiments;
         private float _previousUiScale;
+        private float _previousSciThreshold;
         private bool _previousHideMinSciSlider;
         private GUIStyle _experimentButtonStyle;
         private GUIStyle _experimentLabelStyle;
@@ -226,6 +227,21 @@ namespace ScienceChecklist
 
                 }
             }
+            else if (   (   ScienceChecklistAddon.Config.VeryLowMinScience
+                         && ScienceChecklistAddon.Config.ScienceThreshold > 0.1f
+                        )
+                     || (  !ScienceChecklistAddon.Config.VeryLowMinScience
+                         && ScienceChecklistAddon.Config.ScienceThreshold < 0.1f
+                        )
+                    )
+            {
+                // VeryLowMinScience option was toggled while MinScience slider hidden.
+                // Need to adjust ScienceThreshold accordingly (and re-classify experiments as completed/incomplete)!
+                ScienceChecklistAddon.Config.ScienceThreshold = 0.1f;
+                ScienceChecklistAddon.Config.Save();
+                _parent.Science.UpdateAllScienceInstances();
+                _filter.UpdateFilter();
+            }
 
             int Top = wScale(90 - (ScienceChecklistAddon.Config.HideMinScienceSlider ? 25 : 0));
             if (_filter.DisplayScienceInstances != null)
@@ -299,6 +315,7 @@ namespace ScienceChecklist
             if (   _previousNumExperiments != _filter.DisplayScienceInstances.Count
                 || ScienceChecklistAddon.Config.UiScale != _previousUiScale
                 || ScienceChecklistAddon.Config.HideMinScienceSlider != _previousHideMinSciSlider
+                || ScienceChecklistAddon.Config.ScienceThreshold != _previousSciThreshold
                )
             {
                 windowPos.height = wScale(30) + ((_filter.DisplayScienceInstances.Count + 1) * wScale(35));
@@ -306,6 +323,7 @@ namespace ScienceChecklist
                 _previousNumExperiments = _filter.DisplayScienceInstances.Count;
                 _previousUiScale = ScienceChecklistAddon.Config.UiScale;
                 _previousHideMinSciSlider = ScienceChecklistAddon.Config.HideMinScienceSlider;
+                _previousSciThreshold = ScienceChecklistAddon.Config.ScienceThreshold;
             }
 
             base.DrawWindow();


### PR DESCRIPTION
Fix for next experiment run value when other runs already done but not recovered.
VeryLowMinScience range from 0.0001 to 0.1
Fix for experiments not re-classified as completed or not when MinSci threshold changes.
Fixes for window resizing and button position when hiding / showing MinSci slider.
Fixes for text spanning outside allotted area.
Show Recovered+OnBoard value on experiment button.
Show up to 2 decimal digits in progress bars.
